### PR TITLE
Fix: Force BookCoverImage height and width based on passed props height and width  

### DIFF
--- a/components/Search.tsx
+++ b/components/Search.tsx
@@ -157,8 +157,8 @@ export default function Search({
               className="flex flex-col items-start justify-start gap-2 rounded-none sm:flex-row sm:gap-4"
               onSelect={handleSubmitBook}
             >
-              <BookCoverImage bookSrc={book.coverImg} width={40} height={60} />
-              <div className="">
+              <BookCoverImage bookSrc={book.coverImg} width={48} height={64} />
+              <div>
                 <div className="line-clamp-2">{book.title}</div>
                 <div className="line-clamp-1 text-xs">{book?.authorName}</div>
               </div>

--- a/components/shared/BookCoverImage.tsx
+++ b/components/shared/BookCoverImage.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils";
 import Image from "next/image";
 import { useState } from "react";
 
@@ -14,19 +15,27 @@ export default function BookCoverImage({
   const [src, setSrc] = useState(bookSrc);
   // TODO: Figure out how to update image on 404 error
   return (
-    <Image
-      {...props}
-      src={`https://covers.openlibrary.org/b/olid/${src}-M.jpg?default=false`}
-      alt="book cover"
-      className="aspect-none rounded-xl object-cover"
-      width={width}
-      height={height}
-      loading="lazy"
-      placeholder="blur"
-      blurDataURL={`https://generated.vusercontent.net/placeholder.svg`}
-      onError={() => {
-        setSrc("https://generated.vusercontent.net/placeholder.svg");
-      }}
-    />
+    <div
+      // className="min-h-min w-max overflow-hidden rounded-xl bg-neutral-100/50 dark:bg-neutral-800"
+      className={cn(
+        "overflow-hidden rounded-xl bg-neutral-100/50 dark:bg-neutral-800",
+        `h-[${height}px] w-[${width}px]`
+      )}
+    >
+      <Image
+        {...props}
+        src={`https://covers.openlibrary.org/b/olid/${src}-M.jpg?default=false`}
+        alt="book cover"
+        className="h-full rounded-xl object-cover"
+        width={width}
+        height={height}
+        loading="lazy"
+        placeholder="blur"
+        blurDataURL={`https://generated.vusercontent.net/placeholder.svg`}
+        onError={() => {
+          setSrc("https://generated.vusercontent.net/placeholder.svg");
+        }}
+      />
+    </div>
   );
 }

--- a/components/shared/BookCoverImage.tsx
+++ b/components/shared/BookCoverImage.tsx
@@ -16,7 +16,6 @@ export default function BookCoverImage({
   // TODO: Figure out how to update image on 404 error
   return (
     <div
-      // className="min-h-min w-max overflow-hidden rounded-xl bg-neutral-100/50 dark:bg-neutral-800"
       className={cn(
         "overflow-hidden rounded-xl bg-neutral-100/50 dark:bg-neutral-800",
         `h-[${height}px] w-[${width}px]`


### PR DESCRIPTION
## Changes

- Added wrapper element to `BookCoverImage` with dynamic height and width property and background styling when no image is available. 
- Prevents layout shifts while searching for books 